### PR TITLE
Add bonded devices support

### DIFF
--- a/custom_components/rapt_cloud_link/__init__.py
+++ b/custom_components/rapt_cloud_link/__init__.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 import logging
 
+from .coordinator.bonded_devices_coordinator import BondedDevicesDataUpdateCoordinator
 from .coordinator.brewzilla_coordinator import BrewZillaDataUpdateCoordinator
 from .coordinator.hydrometer_coordinator import HydrometerDataUpdateCoordinator
 from .coordinator.temperature_controller_coordinator import TemperatureControllerDataUpdateCoordinator
@@ -21,10 +22,12 @@ async def async_setup_entry(hass, entry):
     token_manager = TokenManager(hass, email, api_token, entry)
 
     # Coordinators
+    bonded_devices_coordinator = BondedDevicesDataUpdateCoordinator(hass, token_manager, update_interval, entry)
     brewzilla_coordinator = BrewZillaDataUpdateCoordinator(hass, token_manager, update_interval, entry)
     hydrometer_coordinator = HydrometerDataUpdateCoordinator(hass, token_manager, update_interval, entry)
     temperature_controller_coordinator = TemperatureControllerDataUpdateCoordinator(hass, token_manager, update_interval, entry)
 
+    await bonded_devices_coordinator.async_config_entry_first_refresh()
     await brewzilla_coordinator.async_config_entry_first_refresh()
     await hydrometer_coordinator.async_config_entry_first_refresh()
     await temperature_controller_coordinator.async_config_entry_first_refresh()
@@ -32,6 +35,7 @@ async def async_setup_entry(hass, entry):
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
         "token_manager": token_manager,
+        "bonded_devices_coordinator": bonded_devices_coordinator,
         "brewzilla_coordinator": brewzilla_coordinator,
         "hydrometer_coordinator": hydrometer_coordinator,
         "temperature_controller_coordinator": temperature_controller_coordinator,

--- a/custom_components/rapt_cloud_link/api/bonded_devices_api.py
+++ b/custom_components/rapt_cloud_link/api/bonded_devices_api.py
@@ -1,0 +1,33 @@
+import logging
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from ..const import API_BASE_URL
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class BondedDevicesAPI:
+    def __init__(self, hass, token, entry):
+        self.hass = hass
+        self.token = token
+        self.entry = entry
+
+    def _build_headers(self):
+        return {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+        }
+
+    def _get_url(self, path: str) -> str:
+        return f"{API_BASE_URL}{path}"
+
+    async def get_bonded_devices(self):
+        session = async_get_clientsession(self.hass)
+        url = self._get_url("/BondedDevices/GetBondedDevices")
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Accept": "application/json",
+        }
+        async with session.get(url, headers=headers) as resp:
+            resp.raise_for_status()
+            return await resp.json()

--- a/custom_components/rapt_cloud_link/base.py
+++ b/custom_components/rapt_cloud_link/base.py
@@ -8,6 +8,7 @@ from .const import DOMAIN
 
 class BaseRaptEntity(CoordinatorEntity):
     """Base class for all RAPT entities."""
+
     def __init__(self, coordinator, device_id, device_name=None, model="RAPT"):
         super().__init__(coordinator)
         device_name = coordinator.data.get(device_id, {}).get("name", f"Device {device_id}")
@@ -18,6 +19,7 @@ class BaseRaptEntity(CoordinatorEntity):
             "name": self._device_name,
             "manufacturer": "RAPT",
             "model": model,
+            "sw_version": coordinator.data.get(device_id, {}).get("firmwareVersion"),
         }
 
     async def async_added_to_hass(self):
@@ -36,6 +38,7 @@ class BaseRaptEntity(CoordinatorEntity):
 
 class BaseRaptSensor(BaseRaptEntity, SensorEntity):
     """Base class for RAPT sensors."""
+
     def __init__(self, coordinator, device_id, name_suffix, unique_suffix, unit=None, model="RAPT"):
         super().__init__(coordinator, device_id, model=model)
         self._attr_name = f"{self._device_name} {name_suffix}"
@@ -45,7 +48,20 @@ class BaseRaptSensor(BaseRaptEntity, SensorEntity):
 
 class BaseRaptNumber(BaseRaptEntity, NumberEntity):
     """Base class for RAPT numbers."""
-    def __init__(self, coordinator, device_id, name_suffix, unique_suffix, unit=None, min_val=None, max_val=None, step=None, mode=None, model="RAPT"):
+
+    def __init__(
+        self,
+        coordinator,
+        device_id,
+        name_suffix,
+        unique_suffix,
+        unit=None,
+        min_val=None,
+        max_val=None,
+        step=None,
+        mode=None,
+        model="RAPT",
+    ):
         super().__init__(coordinator, device_id, model=model)
         self._attr_name = f"{self._device_name} {name_suffix}"
         self._attr_unique_id = f"{device_id}_{unique_suffix}"
@@ -59,6 +75,7 @@ class BaseRaptNumber(BaseRaptEntity, NumberEntity):
 
 class BaseRaptSwitch(BaseRaptEntity, SwitchEntity):
     """Base class for RAPT switches."""
+
     def __init__(self, coordinator, device_id, name_suffix, unique_suffix, model="RAPT"):
         super().__init__(coordinator, device_id, model=model)
         self._attr_name = f"{self._device_name} {name_suffix}"

--- a/custom_components/rapt_cloud_link/const.py
+++ b/custom_components/rapt_cloud_link/const.py
@@ -7,3 +7,10 @@ TOKEN_URL = "https://id.rapt.io/connect/token"
 
 CONF_TEMPERATURE_UNIT = "temperature_unit"
 DEFAULT_TEMPERATURE_UNIT = "C"
+
+BONDED_DEVICE_TYPES = [
+    "BLEHumidity",
+    "BLEPressure",
+    "BLETemperature",
+    "BLETempHumidity",
+]

--- a/custom_components/rapt_cloud_link/coordinator/bonded_devices_coordinator.py
+++ b/custom_components/rapt_cloud_link/coordinator/bonded_devices_coordinator.py
@@ -1,0 +1,18 @@
+from .base_coordinator import BaseRaptCoordinator
+from ..api.bonded_devices_api import BondedDevicesAPI
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+
+class BondedDevicesDataUpdateCoordinator(BaseRaptCoordinator):
+    def __init__(self, hass, token_manager, update_interval, entry):
+        super().__init__(
+            hass, token_manager, update_interval, entry, name="Bonded Devices API"
+        )
+
+    async def _async_update_data(self):
+        try:
+            api = await self._get_token_and_api(BondedDevicesAPI)
+            devices = await api.get_bonded_devices()
+            return {device["id"]: device for device in devices if "id" in device}
+        except Exception as err:
+            raise UpdateFailed(f"Failed to fetch Bonded Devices data: {err}") from err

--- a/custom_components/rapt_cloud_link/sensor.py
+++ b/custom_components/rapt_cloud_link/sensor.py
@@ -5,7 +5,7 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorStateClass,
 )
-from .const import CONF_TEMPERATURE_UNIT, DEFAULT_TEMPERATURE_UNIT, DOMAIN
+from .const import BONDED_DEVICE_TYPES, CONF_TEMPERATURE_UNIT, DEFAULT_TEMPERATURE_UNIT, DOMAIN
 from .base import BaseRaptSensor
 
 _LOGGER = logging.getLogger(__name__)
@@ -15,8 +15,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     brewzilla_coordinator = hass.data[DOMAIN][entry.entry_id]["brewzilla_coordinator"]
     hydrometer_coordinator = hass.data[DOMAIN][entry.entry_id]["hydrometer_coordinator"]
     temperature_controller_coordinator = hass.data[DOMAIN][entry.entry_id]["temperature_controller_coordinator"]
+    bonded_devices_coordinator = hass.data[DOMAIN][entry.entry_id]["bonded_devices_coordinator"]
 
     sensors = []
+
+    # Bonded Devices
+    for device_id, device in bonded_devices_coordinator.data.items():
+        if device.get("deviceType") in BONDED_DEVICE_TYPES:
+            device_type = device.get("deviceType")
+            if "Temp" in device_type:
+                sensors.append(BondedDeviceTemperatureSensor(bonded_devices_coordinator, device_id))
+            if "Humidity" in device_type:
+                sensors.append(BondedDeviceHumiditySensor(bonded_devices_coordinator, device_id))
+            if "Pressure" in device_type:
+                sensors.append(BondedDevicePressureSensor(bonded_devices_coordinator, device_id))
+            sensors.append(BondedDeviceBatterySensor(bonded_devices_coordinator, device_id))
 
     # BrewZilla
     for device_id, device in brewzilla_coordinator.data.items():
@@ -212,9 +225,83 @@ class TemperatureControllerTemperatureSensor(BaseRaptSensor):
     def unit_of_measurement(self):
         unit = self.coordinator.config_entry.data.get(CONF_TEMPERATURE_UNIT, DEFAULT_TEMPERATURE_UNIT)
         return "°F" if unit == "F" else "°C"
+
     @property
     def native_value(self):
         device = self.coordinator.data.get(self._device_id)
         if device:
             return round(device.get("temperature"), 1)
+        return None
+
+
+# ---------------------
+# Bonded Devices
+# ---------------------
+class BondedDeviceTemperatureSensor(BaseRaptSensor):
+    """Bonded Device Temperature Sensor."""
+
+    def __init__(self, coordinator, device_id: str):
+        super().__init__(coordinator, device_id, model="Bonded Device", name_suffix="Temperature", unique_suffix="temperature", unit="°C")
+        self._attr_device_class = SensorDeviceClass.TEMPERATURE
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def unit_of_measurement(self):
+        unit = self.coordinator.config_entry.data.get(CONF_TEMPERATURE_UNIT, DEFAULT_TEMPERATURE_UNIT)
+        return "°F" if unit == "F" else "°C"
+
+    @property
+    def native_value(self):
+        device = self.coordinator.data.get(self._device_id)
+        if device:
+            return device.get("temperature")
+        return None
+
+
+class BondedDeviceHumiditySensor(BaseRaptSensor):
+    """Bonded Device Humidity Sensor."""
+
+    def __init__(self, coordinator, device_id: str):
+        super().__init__(coordinator, device_id, model="Bonded Device", name_suffix="Humidity", unique_suffix="humidity", unit="%")
+        self._attr_device_class = SensorDeviceClass.HUMIDITY
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def native_value(self):
+        device = self.coordinator.data.get(self._device_id)
+        if device and "telemetry" in device and device["telemetry"]:
+            return device["telemetry"][0].get("humidity")
+        return None
+
+
+class BondedDevicePressureSensor(BaseRaptSensor):
+    """Bonded Device Pressure Sensor."""
+
+    def __init__(self, coordinator, device_id: str):
+        super().__init__(coordinator, device_id, model="Bonded Device", name_suffix="Pressure", unique_suffix="pressure", unit="kPa")
+        self._attr_device_class = SensorDeviceClass.PRESSURE
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def native_value(self):
+        device = self.coordinator.data.get(self._device_id)
+        if device and "telemetry" in device and device["telemetry"]:
+            return device["telemetry"][0].get("pressure")
+        return None
+
+
+class BondedDeviceBatterySensor(BaseRaptSensor):
+    """Bonded Device Battery Sensor."""
+
+    def __init__(self, coordinator, device_id: str):
+        super().__init__(coordinator, device_id, model="Bonded Device", name_suffix="Battery", unique_suffix="battery", unit="%")
+        self._attr_device_class = SensorDeviceClass.BATTERY
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def native_value(self):
+        """Return the current battery."""
+        device = self.coordinator.data.get(self._device_id)
+        if device:
+            return round(device.get("battery"), 1)
         return None

--- a/custom_components/rapt_cloud_link/sensor.py
+++ b/custom_components/rapt_cloud_link/sensor.py
@@ -50,7 +50,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         # name = device.get("name", f"Temperature Controller {device_id}")
         sensors.append(TemperatureControllerTemperatureSensor(temperature_controller_coordinator, device_id))
 
-
     # Add sensors if any
     if sensors:
         async_add_entities(sensors, update_before_add=True)
@@ -61,6 +60,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 # ---------------------
 class BrewZillaTemperatureSensor(BaseRaptSensor):
     """BrewZilla Temperature Sensor."""
+
     def __init__(self, coordinator, device_id: str):
         super().__init__(
             coordinator,
@@ -68,7 +68,7 @@ class BrewZillaTemperatureSensor(BaseRaptSensor):
             model="BrewZilla",
             name_suffix="Temperature",
             unique_suffix="temperature",
-            unit="°C"
+            unit="°C",
         )
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
@@ -77,22 +77,25 @@ class BrewZillaTemperatureSensor(BaseRaptSensor):
     def unit_of_measurement(self):
         unit = self.coordinator.config_entry.data.get(CONF_TEMPERATURE_UNIT, DEFAULT_TEMPERATURE_UNIT)
         return "°F" if unit == "F" else "°C"
+
     @property
     def native_value(self):
         device = self.coordinator.data.get(self._device_id)
         if device:
             return device.get("temperature")
         return None
-    
+
+
 class BrewZillaConnectionStateSensor(BaseRaptSensor):
     """BrewZilla Connection State Sensor."""
+
     def __init__(self, coordinator, device_id: str):
         super().__init__(
             coordinator,
             device_id,
             model="BrewZilla",
             name_suffix="Connection",
-            unique_suffix="connection_state"
+            unique_suffix="connection_state",
         )
         self._attr_device_class = SensorDeviceClass.ENUM
         self._attr_options = ["Connected", "Disconnected"]
@@ -104,13 +107,14 @@ class BrewZillaConnectionStateSensor(BaseRaptSensor):
         if device:
             return device.get("connectionState", "Disconnected")
         return "Disconnected"
-    
+
 
 # ---------------------
 # Hydrometer
 # ---------------------
 class HydrometerTemperatureSensor(BaseRaptSensor):
     """Hydrometer Temperature Sensor."""
+
     def __init__(self, coordinator, device_id: str):
         super().__init__(
             coordinator,
@@ -118,7 +122,7 @@ class HydrometerTemperatureSensor(BaseRaptSensor):
             model="Hydrometer",
             name_suffix="Temperature",
             unique_suffix="temperature",
-            unit="°C"
+            unit="°C",
         )
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
@@ -127,15 +131,18 @@ class HydrometerTemperatureSensor(BaseRaptSensor):
     def unit_of_measurement(self):
         unit = self.coordinator.config_entry.data.get(CONF_TEMPERATURE_UNIT, DEFAULT_TEMPERATURE_UNIT)
         return "°F" if unit == "F" else "°C"
+
     @property
     def native_value(self):
         device = self.coordinator.data.get(self._device_id)
         if device:
             return device.get("temperature")
         return None
-    
+
+
 class HydrometerGravitySensor(BaseRaptSensor):
     """Hydrometer Gravity Sensor."""
+
     def __init__(self, coordinator, device_id: str):
         super().__init__(
             coordinator,
@@ -143,9 +150,9 @@ class HydrometerGravitySensor(BaseRaptSensor):
             model="Hydrometer",
             name_suffix="Gravity",
             unique_suffix="gravity",
-            unit="SG"  # Specific Gravity
+            unit="SG",  # Specific Gravity
         )
-        self._attr_device_class = None # No specific device class for gravity
+        self._attr_device_class = None  # No specific device class for gravity
         self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
@@ -158,10 +165,11 @@ class HydrometerGravitySensor(BaseRaptSensor):
                 sg /= 10
             return round(sg, 3)
         return None
-    
+
 
 class HydrometerBatterySensor(BaseRaptSensor):
     """Hydrometer Battery Sensor."""
+
     def __init__(self, coordinator, device_id: str):
         super().__init__(
             coordinator,
@@ -169,7 +177,7 @@ class HydrometerBatterySensor(BaseRaptSensor):
             model="Hydrometer",
             name_suffix="Battery",
             unique_suffix="battery",
-            unit="%"
+            unit="%",
         )
         self._attr_device_class = SensorDeviceClass.BATTERY
         self._attr_state_class = SensorStateClass.MEASUREMENT
@@ -181,16 +189,18 @@ class HydrometerBatterySensor(BaseRaptSensor):
         if device:
             return round(device.get("battery"), 1)
         return None
-    
+
+
 class HydrometerConnectionStateSensor(BaseRaptSensor):
     """Hydrometer Connection State Sensor."""
+
     def __init__(self, coordinator, device_id: str):
         super().__init__(
             coordinator,
             device_id,
             model="Hydrometer",
             name_suffix="Connection",
-            unique_suffix="connection_state"
+            unique_suffix="connection_state",
         )
         self._attr_device_class = SensorDeviceClass.ENUM
         self._attr_options = ["Connected", "Disconnected"]
@@ -209,6 +219,7 @@ class HydrometerConnectionStateSensor(BaseRaptSensor):
 # ---------------------
 class TemperatureControllerTemperatureSensor(BaseRaptSensor):
     """TemperatureController Temperature Sensor."""
+
     def __init__(self, coordinator, device_id: str):
         super().__init__(
             coordinator,
@@ -216,7 +227,7 @@ class TemperatureControllerTemperatureSensor(BaseRaptSensor):
             model="Temperature Controller",
             name_suffix="Temperature",
             unique_suffix="temperature",
-            unit="°C"
+            unit="°C",
         )
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
@@ -241,7 +252,16 @@ class BondedDeviceTemperatureSensor(BaseRaptSensor):
     """Bonded Device Temperature Sensor."""
 
     def __init__(self, coordinator, device_id: str):
-        super().__init__(coordinator, device_id, model="Bonded Device", name_suffix="Temperature", unique_suffix="temperature", unit="°C")
+        device = coordinator.data.get(device_id, {})
+        model = f"{device.get('deviceType', 'Bonded Device')} (Bonded Device)"
+        super().__init__(
+            coordinator,
+            device_id,
+            model=model,
+            name_suffix="Temperature",
+            unique_suffix="temperature",
+            unit="°C",
+        )
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -262,7 +282,16 @@ class BondedDeviceHumiditySensor(BaseRaptSensor):
     """Bonded Device Humidity Sensor."""
 
     def __init__(self, coordinator, device_id: str):
-        super().__init__(coordinator, device_id, model="Bonded Device", name_suffix="Humidity", unique_suffix="humidity", unit="%")
+        device = coordinator.data.get(device_id, {})
+        model = f"{device.get('deviceType', 'Bonded Device')} (Bonded Device)"
+        super().__init__(
+            coordinator,
+            device_id,
+            model=model,
+            name_suffix="Humidity",
+            unique_suffix="humidity",
+            unit="%",
+        )
         self._attr_device_class = SensorDeviceClass.HUMIDITY
         self._attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -278,7 +307,16 @@ class BondedDevicePressureSensor(BaseRaptSensor):
     """Bonded Device Pressure Sensor."""
 
     def __init__(self, coordinator, device_id: str):
-        super().__init__(coordinator, device_id, model="Bonded Device", name_suffix="Pressure", unique_suffix="pressure", unit="kPa")
+        device = coordinator.data.get(device_id, {})
+        model = f"{device.get('deviceType', 'Bonded Device')} (Bonded Device)"
+        super().__init__(
+            coordinator,
+            device_id,
+            model=model,
+            name_suffix="Pressure",
+            unique_suffix="pressure",
+            unit="kPa",
+        )
         self._attr_device_class = SensorDeviceClass.PRESSURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -294,7 +332,16 @@ class BondedDeviceBatterySensor(BaseRaptSensor):
     """Bonded Device Battery Sensor."""
 
     def __init__(self, coordinator, device_id: str):
-        super().__init__(coordinator, device_id, model="Bonded Device", name_suffix="Battery", unique_suffix="battery", unit="%")
+        device = coordinator.data.get(device_id, {})
+        model = f"{device.get('deviceType', 'Bonded Device')} (Bonded Device)"
+        super().__init__(
+            coordinator,
+            device_id,
+            model=model,
+            name_suffix="Battery",
+            unique_suffix="battery",
+            unit="%",
+        )
         self._attr_device_class = SensorDeviceClass.BATTERY
         self._attr_state_class = SensorStateClass.MEASUREMENT
 


### PR DESCRIPTION
This PR adds support for bonded devices such as the [RAPT Bluetooth Thermometer](https://kegland.com.au/products/rapt-bluetooth-thermometer-20-to-300c-20cm-htc-probe):

<img width="1320" height="910" alt="image" src="https://github.com/user-attachments/assets/e1f83583-f246-43ac-a0f8-ed759fdf753b" />

<img width="1442" height="1027" alt="image" src="https://github.com/user-attachments/assets/5685d98a-9df2-407b-9ddc-d0838e80f371" />
